### PR TITLE
feat: support cnpg resources

### DIFF
--- a/cmd/resources.go
+++ b/cmd/resources.go
@@ -219,6 +219,13 @@ func extractResourcesFromManifest(
 		standardWorkload := ((kind == "Deployment" || kind == "StatefulSet" || kind == "DaemonSet") && apiVersion == "apps/v1") ||
 			(kind == "CronJob" && apiVersion == "batch/v1")
 		if !standardWorkload {
+			resCRD, err := extractResourcesFromCRD(ctx, clientset, vpaClient, prometheusClient, release, doc, namespace, metricsWindow, aggregation)
+			if err != nil {
+				continue
+			}
+
+			res = append(res, resCRD...)
+
 			continue
 		}
 

--- a/cmd/resources_crd.go
+++ b/cmd/resources_crd.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 Serge Logvinov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	v1prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
+
+	"github.com/sergelogvinov/helm-resources/pkg/metrics"
+	"github.com/sergelogvinov/helm-resources/pkg/resources"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	vpa "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/yaml"
+)
+
+func extractResourcesFromCRD(
+	ctx context.Context,
+	clientset *kubernetes.Clientset,
+	vpaClient vpa.Interface,
+	prometheusClient v1prometheus.API,
+	release string,
+	manifest string,
+	namespace,
+	metricsWindow,
+	aggregation string,
+) ([]resources.ResourceInfo, error) {
+	var res []resources.ResourceInfo
+
+	var obj unstructured.Unstructured
+	if err := yaml.Unmarshal([]byte(manifest), &obj); err != nil {
+		return nil, err // Skip invalid YAML
+	}
+
+	kind := obj.GetKind()
+	apiVersion := obj.GetAPIVersion()
+
+	switch apiVersion + "/" + kind { //nolint:gocritic
+	case "postgresql.cnpg.io/v1/Cluster":
+		return extractCNPGClusterResources(ctx, clientset, vpaClient, prometheusClient, release, obj, namespace, metricsWindow, aggregation)
+	case "postgresql.cnpg.io/v1/Pooler":
+		return extractCNPGPoolerResources(ctx, clientset, vpaClient, prometheusClient, release, obj, namespace, metricsWindow, aggregation)
+	}
+
+	return res, nil
+}
+
+// extractCNPGClusterResources extracts resource information from a CNPG Cluster resource
+func extractCNPGClusterResources(
+	ctx context.Context,
+	_ *kubernetes.Clientset,
+	vpaClient vpa.Interface,
+	prometheusClient v1prometheus.API,
+	release string,
+	obj unstructured.Unstructured,
+	namespace,
+	metricsWindow,
+	aggregation string,
+) ([]resources.ResourceInfo, error) {
+	clusterName := obj.GetName()
+
+	replicas := "unknown"
+	if instances, ok, err := unstructured.NestedInt64(obj.Object, "spec", "instances"); err == nil && ok {
+		replicas = fmt.Sprintf("%d", instances)
+	}
+
+	resInfo := resources.ResourceInfo{
+		Release:   release,
+		Kind:      "Cluster",
+		Name:      clusterName,
+		Replicas:  replicas,
+		Container: "postgres",
+	}
+
+	resourcesSpec, ok, err := unstructured.NestedMap(obj.Object, "spec", "resources")
+	if err != nil || !ok {
+		return []resources.ResourceInfo{resInfo}, err
+	}
+
+	if len(resourcesSpec) > 0 {
+		extractContainerResources(resourcesSpec, &resInfo)
+	}
+
+	cpuUsage, memUsage := metrics.GetContainerMetrics(ctx, vpaClient, prometheusClient, namespace, resInfo.Kind, clusterName, resInfo.Container, metricsWindow, aggregation)
+	resInfo.CPUUsage = cpuUsage
+	resInfo.MemUsage = memUsage
+
+	return []resources.ResourceInfo{resInfo}, nil
+}
+
+// extractCNPGPoolerResources extracts resource information from a CNPG Pooler resource
+func extractCNPGPoolerResources(
+	ctx context.Context,
+	_ *kubernetes.Clientset,
+	vpaClient vpa.Interface,
+	prometheusClient v1prometheus.API,
+	release string,
+	obj unstructured.Unstructured,
+	namespace,
+	metricsWindow,
+	aggregation string,
+) ([]resources.ResourceInfo, error) {
+	poolerName := obj.GetName()
+
+	replicas := "unknown"
+	if instances, ok, err := unstructured.NestedInt64(obj.Object, "spec", "instances"); err == nil && ok {
+		replicas = fmt.Sprintf("%d", instances)
+	}
+
+	resInfo := resources.ResourceInfo{
+		Release:   release,
+		Kind:      "Pooler",
+		Name:      poolerName,
+		Replicas:  replicas,
+		Container: "pgbouncer",
+	}
+
+	containers, ok, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+	if err != nil || !ok {
+		return []resources.ResourceInfo{resInfo}, err
+	}
+
+	if len(containers) > 0 {
+		// Use the first container (pgbouncer)
+		if containerMap, ok := containers[0].(map[string]any); ok {
+			resourcesSpec, ok, err := unstructured.NestedMap(containerMap, "resources")
+			if err != nil || !ok {
+				return []resources.ResourceInfo{resInfo}, err
+			}
+
+			extractContainerResources(resourcesSpec, &resInfo)
+		}
+	}
+
+	cpuUsage, memUsage := metrics.GetContainerMetrics(ctx, vpaClient, prometheusClient, namespace, resInfo.Kind, poolerName, resInfo.Container, metricsWindow, aggregation)
+	resInfo.CPUUsage = cpuUsage
+	resInfo.MemUsage = memUsage
+
+	return []resources.ResourceInfo{resInfo}, nil
+}

--- a/cmd/resources_utils.go
+++ b/cmd/resources_utils.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 Serge Logvinov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sergelogvinov/helm-resources/pkg/resources"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func extractContainerResources(resourcesSpec map[string]any, resInfo *resources.ResourceInfo) {
+	if requests, found, err := unstructured.NestedMap(resourcesSpec, "requests"); err == nil && found {
+		if cpuRequest, found := requests["cpu"]; found {
+			cpuStr := fmt.Sprintf("%v", cpuRequest)
+			if cpuStr != "" {
+				if cpuQuantity, err := resource.ParseQuantity(cpuStr); err == nil {
+					resInfo.CPURequest = cpuQuantity.MilliValue()
+				}
+			}
+		}
+
+		if memRequest, found := requests["memory"]; found {
+			memStr := fmt.Sprintf("%v", memRequest)
+			if memStr != "" {
+				if memQuantity, err := resource.ParseQuantity(memStr); err == nil {
+					resInfo.MemRequest = memQuantity.Value()
+				}
+			}
+		}
+	}
+
+	if limits, found, err := unstructured.NestedMap(resourcesSpec, "limits"); err == nil && found {
+		if cpuLimit, found := limits["cpu"]; found {
+			cpuStr := fmt.Sprintf("%v", cpuLimit)
+			if cpuStr != "" {
+				if cpuQuantity, err := resource.ParseQuantity(cpuStr); err == nil {
+					resInfo.CPULimit = cpuQuantity.MilliValue()
+				}
+			}
+		}
+
+		if memLimit, found := limits["memory"]; found {
+			memStr := fmt.Sprintf("%v", memLimit)
+			if memStr != "" {
+				if memQuantity, err := resource.ParseQuantity(memStr); err == nil {
+					resInfo.MemLimit = memQuantity.Value()
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Add postgresql.cnpg cluster and Pooler resoures.

## Why? (reasoning)

https://github.com/sergelogvinov/helm-resources/issues/13

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource monitoring now supports Custom Resource Definitions in addition to standard Kubernetes workloads.
  * Observability added for CNPG Cluster and Pooler resources, reporting CPU/memory requests, limits, and live usage metrics.
  * Non-standard manifests are now inspected for CRD-derived resources, with unsupported definitions gracefully ignored to continue processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->