### PR TITLE
feat: support multiple files for patching

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,8 +59,6 @@ linters:
     - gomodguard
 
     # temporarily disabled linters
-    - copyloopvar
-    - intrange
     - noinlineerr
     - unparam
   settings:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ helm resources my-release --prometheus-url http://prometheus:9090 --aggregation 
 helm resources my-release --prometheus-url http://prometheus:9090 --aggregation avg --metrics-window 1h
 
 # Apply resource recommendations to values file
-helm resources my-release --prometheus-url http://prometheus:9090 --apply-to-values values.yaml
+helm resources my-release --prometheus-url http://prometheus:9090 --values values.yaml
 ```
 
 ### Apply Resource Recommendations
@@ -48,11 +48,11 @@ helm resources my-release --prometheus-url http://prometheus:9090 --apply-to-val
 The plugin can automatically apply resource recommendations to your Helm values file:
 
 ```bash
-# Apply recommendations to a values file
-helm resources my-release --prometheus-url http://prometheus:9090 --apply-to-values values.yaml
+# Apply recommendations across multiple values files
+helm resources my-release --prometheus-url http://prometheus:9090 --values overrides.yaml --values base.yaml
 
 # Apply with specific metrics window and aggregation
-helm resources my-release --prometheus-url http://prometheus:9090 --aggregation max --metrics-window 1h --apply-to-values values.yaml
+helm resources my-release --prometheus-url http://prometheus:9090 --aggregation max --metrics-window 1h --values values.yaml
 ```
 
 This feature will:

--- a/cmd/resources.go
+++ b/cmd/resources.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	v1prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/spf13/cobra"
+	"go.uber.org/multierr"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 
@@ -65,8 +67,8 @@ func newResourcesCommand() *cobra.Command {
 		Example: strings.Join([]string{
 			"  helm resources my-release",
 			"  helm resources my-release --namespace production",
-			"  helm resources my-release -o json",
-			"  helm resources my-release --apply-to-values values.yaml",
+			"  helm resources my-release --output json",
+			"  helm resources my-release --values values.yaml",
 		}, "\n"),
 		Args: cobra.ExactArgs(1),
 		RunE: runResources,
@@ -74,10 +76,10 @@ func newResourcesCommand() *cobra.Command {
 
 	cmd.Flags().StringP("namespace", "n", "", "namespace of the release")
 	cmd.Flags().StringP("output", "o", "table", "output format (table, json, yaml)")
+	cmd.Flags().StringArrayP("values", "f", []string{}, "Apply recommendations to values.yaml file (can be specified multiple times)")
 	cmd.Flags().String("prometheus-url", "", "Prometheus server URL for metrics (e.g., http://prometheus:9090)")
 	cmd.Flags().String("metrics-window", "5m", "Time window for metrics queries (e.g., 5m, 1h, 24h)")
 	cmd.Flags().String("aggregation", "avg", "Aggregation function for metrics (avg, max)")
-	cmd.Flags().String("apply-to-values", "", "Apply recommendations to values.yaml file")
 
 	return cmd
 }
@@ -87,12 +89,12 @@ func runResources(cmd *cobra.Command, args []string) error {
 	flags := cmd.Flags()
 
 	releaseName := args[0]
-	namespace, _ := flags.GetString("namespace")           //nolint: errcheck
-	outputFormat, _ := flags.GetString("output")           //nolint: errcheck
-	prometheusURL, _ := flags.GetString("prometheus-url")  //nolint: errcheck
-	metricsWindow, _ := flags.GetString("metrics-window")  //nolint: errcheck
-	aggregation, _ := flags.GetString("aggregation")       //nolint: errcheck
-	applyToValues, _ := flags.GetString("apply-to-values") //nolint: errcheck
+	namespace, _ := flags.GetString("namespace")          //nolint: errcheck
+	outputFormat, _ := flags.GetString("output")          //nolint: errcheck
+	applyToValues, _ := flags.GetStringArray("values")    //nolint: errcheck
+	prometheusURL, _ := flags.GetString("prometheus-url") //nolint: errcheck
+	metricsWindow, _ := flags.GetString("metrics-window") //nolint: errcheck
+	aggregation, _ := flags.GetString("aggregation")      //nolint: errcheck
 
 	settings := cli.New()
 	if namespace != "" {
@@ -151,12 +153,10 @@ func runResources(cmd *cobra.Command, args []string) error {
 	}
 
 	recommendations := recommend.AnalyzeRecommendations(resources)
-	if applyToValues != "" && len(recommendations) > 0 {
-		if err := applyRecommendationsToValuesFile(recommendations, applyToValues); err != nil {
-			return fmt.Errorf("failed to apply recommendations to values file: %w", err)
+	if len(applyToValues) > 0 && len(recommendations) > 0 {
+		if err := applyRecommendationsToValuesFiles(recommendations, applyToValues); err != nil {
+			return err
 		}
-
-		fmt.Printf("Recommendations applied to %s\n", applyToValues)
 
 		return nil
 	}
@@ -339,35 +339,57 @@ func extractResourcesFromManifest(
 	return res, nil
 }
 
-func applyRecommendationsToValuesFile(recommendations []resources.ResourceRecommendation, valuesFilePath string) error {
+func applyRecommendationsToValuesFiles(recommendations []resources.ResourceRecommendation, valuesFiles []string) error {
 	if len(recommendations) == 0 {
 		return nil
 	}
 
-	valuesData, err := os.ReadFile(valuesFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to read values file: %w", err)
-	}
+	var (
+		retryRecommendations []resources.ResourceRecommendation
+		errs                 error
+	)
 
-	originalText := string(valuesData)
-	updatedText := originalText
+	maxRetries := len(valuesFiles)
 
-	for _, r := range recommendations {
-		newText, err := patch.ApplyPatchesToYaml(updatedText, r)
+	for retry, path := range valuesFiles {
+		valuesData, err := os.ReadFile(path)
 		if err != nil {
-			fmt.Printf("Warning: failed to apply recommendation for %s/%s: %v\n", r.Kind, r.Name, err)
-
-			continue
+			return fmt.Errorf("failed to read values file: %w", err)
 		}
 
-		updatedText = newText
-	}
+		originalText := string(valuesData)
+		updatedText := originalText
 
-	if updatedText != originalText {
-		if err := os.WriteFile(valuesFilePath, []byte(updatedText), 0o644); err != nil {
-			return fmt.Errorf("failed to write updated values file: %w", err)
+		retryRecommendations = []resources.ResourceRecommendation{}
+
+		for _, r := range recommendations {
+			newText, err := patch.ApplyPatchesToYaml(updatedText, r)
+			if err != nil {
+				if !errors.Is(err, patch.ErrNotFound) {
+					return err
+				}
+
+				if retry == maxRetries-1 {
+					errs = multierr.Append(errs, fmt.Errorf("failed to apply recommendation for %s/%s: %w", r.Kind, r.Name, err))
+				}
+
+				retryRecommendations = append(retryRecommendations, r)
+			}
+
+			updatedText = newText
+		}
+
+		if updatedText != originalText {
+			if err := os.WriteFile(path, []byte(updatedText), 0o644); err != nil {
+				return fmt.Errorf("failed to write updated values file %s: %w", path, err)
+			}
+		}
+
+		recommendations = retryRecommendations
+		if len(recommendations) == 0 {
+			break
 		}
 	}
 
-	return nil
+	return errs
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/prometheus/common v0.68.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	go.uber.org/multierr v1.11.0
 	helm.sh/helm/v3 v3.21.0
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1

--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,8 @@ go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpu
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/hack/pg-base.yaml
+++ b/hack/pg-base.yaml
@@ -1,0 +1,23 @@
+autoscaling:
+  enabled: true
+resources:
+  limits:
+    memory: 10Gi
+    cpu: 2
+  requests:
+    memory: 4Gi
+    cpu: 100m
+
+backup:
+  enabled: true
+
+backupCheck:
+  enabled: true
+
+  resources:
+    limits:
+      memory: 4Gi
+      cpu: 200m
+    requests:
+      memory: 4Gi
+      cpu: 100m

--- a/hack/pg.yaml
+++ b/hack/pg.yaml
@@ -1,0 +1,42 @@
+fullnameOverride: pg-backend
+replicaCount: 1
+
+podlabels:
+  project: db
+  severity: critical
+
+postgresqlConfigurationExtra:
+  max_worker_processes: 10
+  max_parallel_workers: 10
+
+postgresqlServerMemory: 2048
+postgresqlMaxConnections: 250
+
+autoscaling:
+  enabled: true
+resources:
+  limits:
+    memory: 10Gi
+    cpu: 2
+  requests:
+    memory: 4Gi
+    cpu: 100m
+
+persistence:
+  enabled: true
+  size: 32Gi
+
+backup:
+  enabled: true
+
+backupCheck:
+  enabled: true
+
+  persistence:
+    size: 32Gi
+
+metrics:
+  enabled: true
+
+nodeSelector:
+  node-role.kubernetes.io/db: ""

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package patch
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -24,6 +25,9 @@ import (
 
 	"sigs.k8s.io/yaml"
 )
+
+// ErrNotFound is returned when a resource is not found.
+var ErrNotFound = errors.New("not found")
 
 // WorkloadPath represents a path to a workload in the YAML structure
 type WorkloadPath struct {
@@ -44,7 +48,7 @@ func ApplyPatchesToYaml(yamlText string, res resources.ResourceRecommendation) (
 
 	workloadPaths := findWorkloadPaths(values, workloadName)
 	if len(workloadPaths) == 0 {
-		return yamlText, fmt.Errorf("workload %s not found", workloadName)
+		return yamlText, ErrNotFound
 	}
 
 	for _, path := range workloadPaths {

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package patch_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,7 +88,7 @@ func TestApplyPatchesToYaml(t *testing.T) {
 				RecommendedCPULimit:   200,
 				RecommendedMemLimit:   512 * 1024 * 1024,
 			},
-			expectErr: fmt.Errorf("workload not-found-service not found"),
+			expectErr: patch.ErrNotFound,
 		},
 		{
 			name: "simple service patch",
@@ -236,7 +235,7 @@ workers:
 			res, err := patch.ApplyPatchesToYaml(tt.yaml, tt.resources)
 
 			if tt.expectErr != nil {
-				assert.EqualError(t, err, tt.expectErr.Error())
+				assert.ErrorIs(t, err, tt.expectErr)
 
 				return
 			}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Allow multiple helm values files to be specified when finding and patching resources.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `resources` command now supports applying recommendations across multiple values files using repeatable `--values` flags.
  * Recommendations are automatically retried against subsequent files when the target is not found.

* **Bug Fixes**
  * Application failures are now collected and reported instead of being silently skipped.

* **Documentation**
  * Updated CLI usage examples to reflect `--values`, including aggregation and metrics-window options.

* **Configuration**
  * Added PostgreSQL configuration examples with autoscaling, persistence, backups, metrics, and resource settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->