### PR TITLE
feat: support patching root workload resources

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/multierr"
+
 	"github.com/sergelogvinov/helm-resources/pkg/resources"
 
 	"sigs.k8s.io/yaml"
@@ -31,7 +33,7 @@ var ErrNotFound = errors.New("not found")
 
 // WorkloadPath represents a path to a workload in the YAML structure
 type WorkloadPath struct {
-	Section   string // services, workers, jobs
+	Section   string // services, workers, jobs, or empty for top-level resources
 	Workload  string // workload name
 	Container string // container name (if applicable)
 }
@@ -45,16 +47,39 @@ func ApplyPatchesToYaml(yamlText string, res resources.ResourceRecommendation) (
 	}
 
 	workloadName, _ := strings.CutPrefix(res.Name, res.Release+"-")
-
 	workloadPaths := findWorkloadPaths(values, workloadName)
+
+	if len(workloadPaths) == 0 {
+		if res.Release == res.Name && values["resources"] != nil {
+			containerName := res.Container
+			if containerName == res.Name {
+				containerName = ""
+			}
+
+			workloadPaths = []WorkloadPath{
+				{
+					Section:  "",
+					Workload: containerName,
+				},
+			}
+		}
+	}
+
 	if len(workloadPaths) == 0 {
 		return yamlText, ErrNotFound
 	}
 
 	for _, path := range workloadPaths {
-		if newText, err := applyResourcePatchesToPath(yamlText, path, res); err == nil {
-			yamlText = newText
+		if path.Container != "" && res.Container != path.Container {
+			continue
 		}
+
+		newText, err := applyResourcePatchesToPath(yamlText, path, res)
+		if err != nil {
+			return "", fmt.Errorf("failed to apply resource patches to path %w", err)
+		}
+
+		yamlText = newText
 	}
 
 	if !strings.HasSuffix(yamlText, "\n") {
@@ -99,31 +124,45 @@ func findWorkloadPaths(values map[string]any, workloadName string) []WorkloadPat
 }
 
 func applyResourcePatchesToPath(yamlText string, path WorkloadPath, rec resources.ResourceRecommendation) (string, error) {
+	var errs error
+
 	if rec.RecommendedCPULimit > 0 {
-		if newText, err := applyValuePatch(yamlText, path, "limits", "cpu", formatCPUForYaml(rec.RecommendedCPULimit)); err == nil {
+		newText, err := applyValuePatch(yamlText, path, "limits", "cpu", formatCPUForYaml(rec.RecommendedCPULimit))
+		if err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
 			yamlText = newText
 		}
 	}
 
 	if rec.RecommendedMemLimit > 0 {
-		if newText, err := applyValuePatch(yamlText, path, "limits", "memory", formatMemoryForYaml(rec.RecommendedMemLimit)); err == nil {
+		newText, err := applyValuePatch(yamlText, path, "limits", "memory", formatMemoryForYaml(rec.RecommendedMemLimit))
+		if err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
 			yamlText = newText
 		}
 	}
 
 	if rec.RecommendedCPURequest > 0 {
-		if newText, err := applyValuePatch(yamlText, path, "requests", "cpu", formatCPUForYaml(rec.RecommendedCPURequest)); err == nil {
+		newText, err := applyValuePatch(yamlText, path, "requests", "cpu", formatCPUForYaml(rec.RecommendedCPURequest))
+		if err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
 			yamlText = newText
 		}
 	}
 
 	if rec.RecommendedMemRequest > 0 {
-		if newText, err := applyValuePatch(yamlText, path, "requests", "memory", formatMemoryForYaml(rec.RecommendedMemRequest)); err == nil {
+		newText, err := applyValuePatch(yamlText, path, "requests", "memory", formatMemoryForYaml(rec.RecommendedMemRequest))
+		if err != nil {
+			errs = multierr.Append(errs, err)
+		} else {
 			yamlText = newText
 		}
 	}
 
-	return yamlText, nil
+	return yamlText, errs
 }
 
 func applyValuePatch(yamlText string, path WorkloadPath, resourceType, resource, newValue string) (string, error) {
@@ -150,11 +189,21 @@ func applyValuePatch(yamlText string, path WorkloadPath, resourceType, resource,
 }
 
 func findTargetLocation(lines []string, path WorkloadPath) (int, int, error) {
-	sectionFound := false
-	workloadFound := false
+	sectionFound := path.Section == ""
+	workloadFound := path.Workload == ""
 	containerFound := path.Container == ""
 	inContainers := false
 	containerIndex := -1
+
+	// The case when resources are defined at the top level (no section, no workload, no container)
+	if sectionFound && workloadFound && containerFound {
+		i, indent := findResourcesSection(lines, 0, 0)
+		if i > 0 {
+			return i - 1, indent, nil
+		}
+
+		return -1, 0, fmt.Errorf("target location not found")
+	}
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -209,7 +258,7 @@ func findTargetLocation(lines []string, path WorkloadPath) (int, int, error) {
 		}
 	}
 
-	return -1, 0, fmt.Errorf("target location not found: %s.%s.%s", path.Section, path.Workload, path.Container)
+	return -1, 0, fmt.Errorf("target location not found: %s/%s/%s", path.Section, path.Workload, path.Container)
 }
 
 func findResourcesSection(lines []string, startLine, baseIndent int) (int, int) {
@@ -222,7 +271,7 @@ func findResourcesSection(lines []string, startLine, baseIndent int) (int, int) 
 		trimmed := strings.TrimSpace(line)
 		indent := len(line) - len(strings.TrimLeft(line, " \t"))
 
-		if trimmed != "" && indent <= baseIndent {
+		if trimmed != "" && baseIndent > 0 && indent <= baseIndent {
 			break
 		}
 

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -26,6 +26,22 @@ import (
 )
 
 const (
+	commonYAML = `
+someOtherField: someValue
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+componentName:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 768Mi
+`
+
 	simpleServiceYAML = `
 someOtherField: someValue
 services:
@@ -77,6 +93,36 @@ func TestApplyPatchesToYaml(t *testing.T) {
 		expect    string
 		expectErr error
 	}{
+		{
+			name: "common patch",
+			yaml: commonYAML,
+			resources: resources.ResourceRecommendation{
+				Release:               "common",
+				Name:                  "common",
+				RecommendedCPURequest: 100,
+				RecommendedMemRequest: 256 * 1024 * 1024,
+				RecommendedCPULimit:   200,
+				RecommendedMemLimit:   512 * 1024 * 1024,
+			},
+			expect: `
+someOtherField: someValue
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 200m
+    memory: 512Mi
+componentName:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 768Mi
+`,
+		},
 		{
 			name: "service not found",
 			yaml: simpleServiceYAML,


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

Some Helm charts define resources at the root level. Add support for patching these root-level resources.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved YAML patching for top-level resources and common resource recommendations.
  * Added support for updating CPU and memory requests and limits in more resource layouts.

* **Bug Fixes**
  * Patch application now reports errors instead of silently ignoring failed updates.
  * Improved detection of resource targets and clearer target-not-found errors.

* **Tests**
  * Added coverage verifying CPU and memory values are correctly updated in common resource configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->