### PR TITLE
feat: support component resource patching

### DIFF
--- a/cmd/resources.go
+++ b/cmd/resources.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/multierr"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/sergelogvinov/helm-resources/pkg/metrics"
 	"github.com/sergelogvinov/helm-resources/pkg/patch"
@@ -147,7 +148,7 @@ func runResources(cmd *cobra.Command, args []string) error {
 		vpaClient = vpaClientset
 	}
 
-	resources, err := extractResourcesFromManifest(ctx, clientset, vpaClient, prometheusClient, releaseName, release.Manifest, settings.Namespace(), metricsWindow, aggregation)
+	resources, err := extractResourcesFromHelmRelease(ctx, clientset, vpaClient, prometheusClient, release, metricsWindow, aggregation)
 	if err != nil {
 		return fmt.Errorf("failed to extract resources: %w", err)
 	}
@@ -189,20 +190,26 @@ func runResources(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func extractResourcesFromManifest(
+// nolint: cyclop,gocyclo
+func extractResourcesFromHelmRelease(
 	ctx context.Context,
 	clientset *kubernetes.Clientset,
 	vpaClient vpa.Interface,
 	prometheusClient v1prometheus.API,
-	release string,
-	manifest string,
-	namespace,
-	metricsWindow,
+	release *release.Release,
+	metricsWindow string,
 	aggregation string,
 ) ([]resources.ResourceInfo, error) {
 	var res []resources.ResourceInfo
 
-	for doc := range strings.SplitSeq(manifest, "---") {
+	namespace := release.Namespace
+	chartName := ""
+
+	if release.Chart != nil && release.Chart.Metadata != nil {
+		chartName = release.Chart.Metadata.Name
+	}
+
+	for doc := range strings.SplitSeq(release.Manifest, "---") {
 		doc = strings.TrimSpace(doc)
 		if doc == "" {
 			continue
@@ -219,7 +226,7 @@ func extractResourcesFromManifest(
 		standardWorkload := ((kind == "Deployment" || kind == "StatefulSet" || kind == "DaemonSet") && apiVersion == "apps/v1") ||
 			(kind == "CronJob" && apiVersion == "batch/v1")
 		if !standardWorkload {
-			resCRD, err := extractResourcesFromCRD(ctx, clientset, vpaClient, prometheusClient, release, doc, namespace, metricsWindow, aggregation)
+			resCRD, err := extractResourcesFromCRD(ctx, clientset, vpaClient, prometheusClient, release.Name, doc, namespace, metricsWindow, aggregation)
 			if err != nil {
 				continue
 			}
@@ -300,7 +307,8 @@ func extractResourcesFromManifest(
 
 		for _, container := range containers {
 			resInfo := resources.ResourceInfo{
-				Release:   release,
+				Chart:     chartName,
+				Release:   release.Name,
 				Kind:      kind,
 				Name:      workloadName,
 				Replicas:  replicas,

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -50,9 +50,10 @@ func ApplyPatchesToYaml(yamlText string, res resources.ResourceRecommendation) (
 	workloadPaths := findWorkloadPaths(values, workloadName)
 
 	if len(workloadPaths) == 0 {
-		if res.Release == res.Name && values["resources"] != nil {
+		switch {
+		case res.Release == res.Name && values["resources"] != nil:
 			containerName := res.Container
-			if containerName == res.Name {
+			if containerName == res.Chart {
 				containerName = ""
 			}
 
@@ -61,6 +62,15 @@ func ApplyPatchesToYaml(yamlText string, res resources.ResourceRecommendation) (
 					Section:  "",
 					Workload: containerName,
 				},
+			}
+		case values[toCamelCase(workloadName)] != nil:
+			if workloadData, ok := values[toCamelCase(workloadName)].(map[string]any); ok {
+				if _, ok := workloadData["resources"].(map[string]any); ok {
+					workloadPaths = append(workloadPaths, WorkloadPath{
+						Section:  "",
+						Workload: toCamelCase(workloadName),
+					})
+				}
 			}
 		}
 	}
@@ -92,7 +102,7 @@ func ApplyPatchesToYaml(yamlText string, res resources.ResourceRecommendation) (
 func findWorkloadPaths(values map[string]any, workloadName string) []WorkloadPath {
 	var paths []WorkloadPath
 
-	for _, section := range []string{"services", "workers"} {
+	for _, section := range []string{"services", "workers", "jobs"} {
 		if sectionData, ok := values[section].(map[string]any); ok {
 			if workloadData, ok := sectionData[workloadName].(map[string]any); ok {
 				if containers, ok := workloadData["containers"].([]any); ok {

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -128,6 +128,35 @@ componentName:
 `,
 		},
 		{
+			name: "common deploy with component patch",
+			yaml: commonYAML,
+			resources: resources.ResourceRecommendation{
+				Release:               "common",
+				Name:                  "component-name",
+				RecommendedCPURequest: 100,
+				RecommendedMemRequest: 256 * 1024 * 1024,
+				RecommendedCPULimit:   200,
+				RecommendedMemLimit:   512 * 1024 * 1024,
+			},
+			expect: `
+someOtherField: someValue
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+componentName:
+  otherField: someValue
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+`,
+		},
+		{
 			name: "service not found",
 			yaml: simpleServiceYAML,
 			resources: resources.ResourceRecommendation{

--- a/pkg/patch/util.go
+++ b/pkg/patch/util.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package patch
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func formatCPUForYaml(milliCores int64) string {
 	if milliCores >= 1000 {
@@ -32,4 +35,21 @@ func formatMemoryForYaml(bytes int64) string {
 	}
 
 	return fmt.Sprintf("%dMi", bytes/(1024*1024))
+}
+
+func toCamelCase(input string) string {
+	parts := strings.Split(input, "-")
+	if len(parts) == 0 {
+		return input
+	}
+
+	for i := 1; i < len(parts); i++ {
+		if len(parts[i]) == 0 {
+			continue
+		}
+
+		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+	}
+
+	return strings.Join(parts, "")
 }

--- a/pkg/recommend/recommendation.go
+++ b/pkg/recommend/recommendation.go
@@ -32,6 +32,7 @@ func AnalyzeRecommendations(res []resources.ResourceInfo) []resources.ResourceRe
 		}
 
 		rec := resources.ResourceRecommendation{
+			Chart:     r.Chart,
 			Release:   r.Release,
 			Kind:      r.Kind,
 			Name:      r.Name,

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -19,6 +19,7 @@ package resources
 
 // ResourceInfo represents the resource requests, limits, and usage for a container within a workload.
 type ResourceInfo struct {
+	Chart      string `json:"chart"`
 	Release    string `json:"release"`
 	Kind       string `json:"kind"`
 	Name       string `json:"name"`
@@ -34,6 +35,7 @@ type ResourceInfo struct {
 
 // ResourceRecommendation represents resource recommendation for a container within a workload.
 type ResourceRecommendation struct {
+	Chart                 string
 	Release               string
 	Kind                  string
 	Name                  string


### PR DESCRIPTION
Some common Helm charts define additional components using camelCase names. Each component has its own `resources` section, which can now be patched.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource information and recommendations now include Helm chart details.
  * Resource patches can target workloads defined under `jobs`, in addition to services and workers.
  * Component-specific resource settings are supported for chart-based deployments.

* **Bug Fixes**
  * Improved workload and container matching when applying resource recommendations.
  * Corrected generated resource patches to preserve accurate CPU and memory limits and requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->