### PR TITLE
feat: integrate kubernetes metrics api

### DIFF
--- a/cmd/resources.go
+++ b/cmd/resources.go
@@ -20,13 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
-	"time"
 
-	"github.com/prometheus/client_golang/api"
-	v1prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/spf13/cobra"
 	"go.uber.org/multierr"
 	"helm.sh/helm/v3/pkg/action"
@@ -43,7 +39,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	vpa "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/yaml"
@@ -90,9 +85,10 @@ func runResources(cmd *cobra.Command, args []string) error {
 	flags := cmd.Flags()
 
 	releaseName := args[0]
-	namespace, _ := flags.GetString("namespace")          //nolint: errcheck
-	outputFormat, _ := flags.GetString("output")          //nolint: errcheck
-	applyToValues, _ := flags.GetStringArray("values")    //nolint: errcheck
+	namespace, _ := flags.GetString("namespace")       //nolint: errcheck
+	outputFormat, _ := flags.GetString("output")       //nolint: errcheck
+	applyToValues, _ := flags.GetStringArray("values") //nolint: errcheck
+
 	prometheusURL, _ := flags.GetString("prometheus-url") //nolint: errcheck
 	metricsWindow, _ := flags.GetString("metrics-window") //nolint: errcheck
 	aggregation, _ := flags.GetString("aggregation")      //nolint: errcheck
@@ -124,31 +120,12 @@ func runResources(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	var (
-		prometheusClient v1prometheus.API
-		vpaClient        vpa.Interface
-	)
-
-	if prometheusURL != "" {
-		promClient, err := api.NewClient(api.Config{
-			Address: prometheusURL,
-			RoundTripper: &http.Transport{
-				IdleConnTimeout: 30 * time.Second,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create Prometheus client: %w", err)
-		}
-
-		prometheusClient = v1prometheus.NewAPI(promClient)
+	metricsClient, err := metrics.New(prometheusURL, metricsWindow, aggregation, config)
+	if err != nil {
+		return fmt.Errorf("failed to create metrics client: %w", err)
 	}
 
-	vpaClientset, err := vpa.NewForConfig(config)
-	if err == nil {
-		vpaClient = vpaClientset
-	}
-
-	resources, err := extractResourcesFromHelmRelease(ctx, clientset, vpaClient, prometheusClient, release, metricsWindow, aggregation)
+	resources, err := extractResourcesFromHelmRelease(ctx, clientset, metricsClient, release)
 	if err != nil {
 		return fmt.Errorf("failed to extract resources: %w", err)
 	}
@@ -194,11 +171,8 @@ func runResources(cmd *cobra.Command, args []string) error {
 func extractResourcesFromHelmRelease(
 	ctx context.Context,
 	clientset *kubernetes.Clientset,
-	vpaClient vpa.Interface,
-	prometheusClient v1prometheus.API,
+	metricsClient *metrics.Client,
 	release *release.Release,
-	metricsWindow string,
-	aggregation string,
 ) ([]resources.ResourceInfo, error) {
 	var res []resources.ResourceInfo
 
@@ -226,7 +200,7 @@ func extractResourcesFromHelmRelease(
 		standardWorkload := ((kind == "Deployment" || kind == "StatefulSet" || kind == "DaemonSet") && apiVersion == "apps/v1") ||
 			(kind == "CronJob" && apiVersion == "batch/v1")
 		if !standardWorkload {
-			resCRD, err := extractResourcesFromCRD(ctx, clientset, vpaClient, prometheusClient, release.Name, doc, namespace, metricsWindow, aggregation)
+			resCRD, err := extractResourcesFromCRD(ctx, clientset, metricsClient, release.Name, doc, namespace)
 			if err != nil {
 				continue
 			}
@@ -335,7 +309,7 @@ func extractResourcesFromHelmRelease(
 				}
 			}
 
-			cpuUsage, memUsage := metrics.GetContainerMetrics(ctx, vpaClient, prometheusClient, namespace, kind, workloadName, container.Name, metricsWindow, aggregation)
+			cpuUsage, memUsage := metricsClient.GetContainerMetrics(ctx, namespace, kind, workloadName, container.Name)
 
 			resInfo.CPUUsage = cpuUsage
 			resInfo.MemUsage = memUsage

--- a/cmd/resources_crd.go
+++ b/cmd/resources_crd.go
@@ -20,13 +20,10 @@ import (
 	"context"
 	"fmt"
 
-	v1prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
-
 	"github.com/sergelogvinov/helm-resources/pkg/metrics"
 	"github.com/sergelogvinov/helm-resources/pkg/resources"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	vpa "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/yaml"
@@ -35,13 +32,10 @@ import (
 func extractResourcesFromCRD(
 	ctx context.Context,
 	clientset *kubernetes.Clientset,
-	vpaClient vpa.Interface,
-	prometheusClient v1prometheus.API,
+	metricsClient *metrics.Client,
 	release string,
 	manifest string,
-	namespace,
-	metricsWindow,
-	aggregation string,
+	namespace string,
 ) ([]resources.ResourceInfo, error) {
 	var res []resources.ResourceInfo
 
@@ -55,11 +49,11 @@ func extractResourcesFromCRD(
 
 	switch apiVersion + "/" + kind { //nolint:gocritic
 	case "postgresql.cnpg.io/v1/Cluster":
-		return extractCNPGClusterResources(ctx, clientset, vpaClient, prometheusClient, release, obj, namespace, metricsWindow, aggregation)
+		return extractCNPGClusterResources(ctx, clientset, metricsClient, release, obj, namespace)
 	case "postgresql.cnpg.io/v1/Pooler":
-		return extractCNPGPoolerResources(ctx, clientset, vpaClient, prometheusClient, release, obj, namespace, metricsWindow, aggregation)
+		return extractCNPGPoolerResources(ctx, clientset, metricsClient, release, obj, namespace)
 	case "clickhouse.altinity.com/v1/ClickHouseInstallation":
-		return extractClickHouseInstallationResources(ctx, clientset, vpaClient, prometheusClient, release, obj, namespace, metricsWindow, aggregation)
+		return extractClickHouseInstallationResources(ctx, clientset, metricsClient, release, obj, namespace)
 	}
 
 	return res, nil
@@ -69,13 +63,10 @@ func extractResourcesFromCRD(
 func extractCNPGClusterResources(
 	ctx context.Context,
 	_ *kubernetes.Clientset,
-	vpaClient vpa.Interface,
-	prometheusClient v1prometheus.API,
+	metricsClient *metrics.Client,
 	release string,
 	obj unstructured.Unstructured,
-	namespace,
-	metricsWindow,
-	aggregation string,
+	namespace string,
 ) ([]resources.ResourceInfo, error) {
 	clusterName := obj.GetName()
 
@@ -101,7 +92,7 @@ func extractCNPGClusterResources(
 		extractContainerResources(resourcesSpec, &resInfo)
 	}
 
-	cpuUsage, memUsage := metrics.GetContainerMetrics(ctx, vpaClient, prometheusClient, namespace, resInfo.Kind, clusterName, resInfo.Container, metricsWindow, aggregation)
+	cpuUsage, memUsage := metricsClient.GetContainerMetrics(ctx, namespace, resInfo.Kind, clusterName, resInfo.Container)
 	resInfo.CPUUsage = cpuUsage
 	resInfo.MemUsage = memUsage
 
@@ -112,13 +103,10 @@ func extractCNPGClusterResources(
 func extractCNPGPoolerResources(
 	ctx context.Context,
 	_ *kubernetes.Clientset,
-	vpaClient vpa.Interface,
-	prometheusClient v1prometheus.API,
+	metricsClient *metrics.Client,
 	release string,
 	obj unstructured.Unstructured,
-	namespace,
-	metricsWindow,
-	aggregation string,
+	namespace string,
 ) ([]resources.ResourceInfo, error) {
 	poolerName := obj.GetName()
 
@@ -152,7 +140,7 @@ func extractCNPGPoolerResources(
 		}
 	}
 
-	cpuUsage, memUsage := metrics.GetContainerMetrics(ctx, vpaClient, prometheusClient, namespace, resInfo.Kind, poolerName, resInfo.Container, metricsWindow, aggregation)
+	cpuUsage, memUsage := metricsClient.GetContainerMetrics(ctx, namespace, resInfo.Kind, poolerName, resInfo.Container)
 	resInfo.CPUUsage = cpuUsage
 	resInfo.MemUsage = memUsage
 
@@ -165,13 +153,10 @@ func extractCNPGPoolerResources(
 func extractClickHouseInstallationResources(
 	ctx context.Context,
 	_ *kubernetes.Clientset,
-	vpaClient vpa.Interface,
-	prometheusClient v1prometheus.API,
+	metricsClient *metrics.Client,
 	release string,
 	obj unstructured.Unstructured,
-	namespace,
-	metricsWindow,
-	aggregation string,
+	namespace string,
 ) ([]resources.ResourceInfo, error) {
 	installationName := obj.GetName()
 	clusterName := installationName
@@ -234,7 +219,7 @@ func extractClickHouseInstallationResources(
 		}
 	}
 
-	cpuUsage, memUsage := metrics.GetContainerMetrics(ctx, vpaClient, prometheusClient, namespace, resInfo.Kind, "chi-"+installationName+"-"+clusterName, resInfo.Container, metricsWindow, aggregation)
+	cpuUsage, memUsage := metricsClient.GetContainerMetrics(ctx, namespace, resInfo.Kind, "chi-"+installationName+"-"+clusterName, resInfo.Container)
 	resInfo.CPUUsage = cpuUsage
 	resInfo.MemUsage = memUsage
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.36.2
 	k8s.io/autoscaler/vertical-pod-autoscaler v1.7.0
 	k8s.io/client-go v0.36.2
+	k8s.io/metrics v0.36.2
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ k8s.io/kube-openapi v0.0.0-20260718133925-74c0ba7c0470 h1:BVDpOsFos+7pz64ZQ3g3mh
 k8s.io/kube-openapi v0.0.0-20260718133925-74c0ba7c0470/go.mod h1:rcZ+P5cEvHQB+m154WBOatIGBgOEPjzmLkXjkHfg3ms=
 k8s.io/kubectl v0.36.2 h1:rpUGGpeL09XVOLep2yle5jrtk//JA1L6ZHfkQQtVEwk=
 k8s.io/kubectl v0.36.2/go.mod h1:gVbQ3B/yb4bSR2ggQ7rd0W6icUSWs7sduH4e16Vii+0=
+k8s.io/metrics v0.36.2 h1:yfUIe2Vwx2cQAIpVYcin1JXdabrRz98oTxP2HJTxHj8=
+k8s.io/metrics v0.36.2/go.mod h1:Q/dNyLLzgSxPu0/e+996Du4pjutfEyyHOKgK0lkncp0=
 k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 h1:jVkFFVfXdXP74B/zbO3hM3hpSFD0xvhQ5U686DPurkE=
 k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3/go.mod h1:M2s5JB1lIYP3jzZdorPLHXIPJzt9vv2muW5a6L9DtNM=
 oras.land/oras-go/v2 v2.6.2 h1:N04RXngAp1LJKTG6ifz3xHPipasEkWr+hFmInja5YKo=

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,54 +20,123 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/api"
 	v1prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/client-go/rest"
+	metricsv1 "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
-// GetContainerMetrics retrieves CPU and memory usage for a container using either Prometheus or Kubernetes Metrics API
-func GetContainerMetrics(
+// Client provides methods to retrieve resource usage metrics for Kubernetes workloads.
+type Client struct {
+	vpaClient        vpa.Interface
+	prometheusClient v1prometheus.API
+	metricsClient    metricsv1.Interface
+	metricsWindow    string
+	aggregation      string
+}
+
+// New creates a new Client with the provided clients and configuration.
+// All parameters are optional; pass nil for clients you don't want to use.
+// metricsWindow specifies the time window for Prometheus queries (e.g., "5m", "1h").
+// aggregation specifies the aggregation function for Prometheus queries ("avg" or "max").
+func New(
+	prometheusURL string,
+	metricsWindow string,
+	aggregation string,
+	config *rest.Config,
+) (*Client, error) {
+	var (
+		prometheusClient v1prometheus.API
+		vpaClient        vpa.Interface
+		metricsClient    metricsv1.Interface
+	)
+
+	if prometheusURL != "" {
+		promClient, err := api.NewClient(api.Config{
+			Address: prometheusURL,
+			RoundTripper: &http.Transport{
+				IdleConnTimeout: 30 * time.Second,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Prometheus client: %w", err)
+		}
+
+		prometheusClient = v1prometheus.NewAPI(promClient)
+	}
+
+	if config != nil {
+		vpaClientset, err := vpa.NewForConfig(config)
+		if err == nil {
+			vpaClient = vpaClientset
+		}
+	}
+
+	if config != nil {
+		metricsClientset, err := metricsv1.NewForConfig(config)
+		if err == nil {
+			metricsClient = metricsClientset
+		}
+	}
+
+	if aggregation != "avg" && aggregation != "max" {
+		aggregation = "avg" // default fallback
+	}
+
+	return &Client{
+		vpaClient:        vpaClient,
+		prometheusClient: prometheusClient,
+		metricsClient:    metricsClient,
+		metricsWindow:    metricsWindow,
+		aggregation:      aggregation,
+	}, nil
+}
+
+// GetContainerMetrics retrieves CPU and memory usage for a container using the configured metrics source.
+// Returns CPU in millicores and memory in bytes.
+func (m *Client) GetContainerMetrics(
 	ctx context.Context,
-	vpaClient vpa.Interface,
-	prometheusClient v1prometheus.API,
 	namespace,
 	kind,
 	workloadName,
-	containerName,
-	metricsWindow,
-	aggregation string,
+	containerName string,
 ) (int64, int64) {
-	if prometheusClient != nil {
-		return GetPrometheusMetrics(ctx, prometheusClient, namespace, workloadName, containerName, metricsWindow, aggregation)
+	if m.prometheusClient != nil {
+		return m.getPrometheusMetrics(ctx, namespace, workloadName, containerName)
 	}
 
-	if vpaClient != nil {
-		return GetVPAMetrics(ctx, vpaClient, namespace, kind, workloadName, containerName)
+	if m.metricsClient != nil {
+		return m.getKubernetesMetrics(ctx, namespace, kind, workloadName, containerName)
+	}
+
+	if m.vpaClient != nil {
+		return m.getVPAMetrics(ctx, namespace, kind, workloadName, containerName)
 	}
 
 	return 0, 0
 }
 
-// GetPrometheusMetrics retrieves CPU and memory usage from Prometheus
-func GetPrometheusMetrics(ctx context.Context, prometheusClient v1prometheus.API, namespace, workloadName, containerName, metricsWindow, aggregation string) (int64, int64) {
-	if aggregation != "avg" && aggregation != "max" {
-		aggregation = "avg" // default fallback
-	}
+// getPrometheusMetrics retrieves CPU and memory usage from Prometheus
+func (m *Client) getPrometheusMetrics(ctx context.Context, namespace, workloadName, containerName string) (int64, int64) {
+	cpuQuery := fmt.Sprintf(`%s(rate(container_cpu_usage_seconds_total{namespace="%s",pod=~"%s.*",container="%s"}[%s])) * 1000`, m.aggregation, namespace, workloadName, containerName, m.metricsWindow)
 
-	cpuQuery := fmt.Sprintf(`%s(rate(container_cpu_usage_seconds_total{namespace="%s",pod=~"%s.*",container="%s"}[%s])) * 1000`, aggregation, namespace, workloadName, containerName, metricsWindow)
-
-	cpuResult, _, err := prometheusClient.Query(ctx, cpuQuery, time.Now())
+	cpuResult, _, err := m.prometheusClient.Query(ctx, cpuQuery, time.Now())
 	if err != nil {
 		return 0, 0
 	}
 
-	memQuery := fmt.Sprintf(`%s(container_memory_usage_bytes{namespace="%s",pod=~"%s.*",container="%s"}[%s])`, aggregation, namespace, workloadName, containerName, metricsWindow)
+	memQuery := fmt.Sprintf(`%s(container_memory_usage_bytes{namespace="%s",pod=~"%s.*",container="%s"}[%s])`, m.aggregation, namespace, workloadName, containerName, m.metricsWindow)
 
-	memResult, _, err := prometheusClient.Query(ctx, memQuery, time.Now())
+	memResult, _, err := m.prometheusClient.Query(ctx, memQuery, time.Now())
 	if err != nil {
 		return 0, 0
 	}
@@ -85,9 +154,51 @@ func GetPrometheusMetrics(ctx context.Context, prometheusClient v1prometheus.API
 	return cpuUsage, memUsage
 }
 
-// GetVPAMetrics retrieves CPU and memory recommendations from VPA
-func GetVPAMetrics(ctx context.Context, vpaClient vpa.Interface, namespace, kind, workloadName, containerName string) (int64, int64) {
-	vpaList, err := vpaClient.AutoscalingV1().VerticalPodAutoscalers(namespace).List(ctx, metav1.ListOptions{})
+// getKubernetesMetrics retrieves CPU and Memory usage for a container from the
+// Kubernetes Metrics API (metrics.k8s.io/v1).
+func (m *Client) getKubernetesMetrics(ctx context.Context, namespace, kind, workloadName, containerName string) (int64, int64) {
+	podMetricsList, err := m.metricsClient.MetricsV1beta1().PodMetricses(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, 0
+	}
+
+	var (
+		totalCPU int64
+		totalMem int64
+		count    int
+	)
+
+	for _, podMetrics := range podMetricsList.Items {
+		podName := podMetrics.Name
+
+		if !m.podBelongsToWorkload(podName, kind, workloadName) {
+			continue
+		}
+
+		for _, containerMetrics := range podMetrics.Containers {
+			if containerMetrics.Name != containerName {
+				continue
+			}
+
+			cpu := containerMetrics.Usage[v1.ResourceCPU]
+			mem := containerMetrics.Usage[v1.ResourceMemory]
+
+			totalCPU += cpu.MilliValue()
+			totalMem += mem.Value()
+			count++
+		}
+	}
+
+	if count == 0 {
+		return 0, 0
+	}
+
+	return totalCPU / int64(count), totalMem / int64(count)
+}
+
+// getVPAMetrics retrieves CPU and memory recommendations from VPA
+func (m *Client) getVPAMetrics(ctx context.Context, namespace, kind, workloadName, containerName string) (int64, int64) {
+	vpaList, err := m.vpaClient.AutoscalingV1().VerticalPodAutoscalers(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, 0
 	}
@@ -117,4 +228,17 @@ func GetVPAMetrics(ctx context.Context, vpaClient vpa.Interface, namespace, kind
 	}
 
 	return 0, 0
+}
+
+// podBelongsToWorkload reports whether a pod name belongs to the given workload.
+func (m *Client) podBelongsToWorkload(podName, kind, workloadName string) bool {
+	switch kind {
+	case "StatefulSet":
+		// StatefulSet pods are named "<workload>-<ordinal>".
+		return podName == workloadName || (len(podName) > len(workloadName)+1 && strings.HasPrefix(podName, workloadName+"-"))
+	default:
+		// Deployment, DaemonSet, CronJob/Job pods are named "<workload>-<hash>-<rand>"
+		// or "<workload>-<rand>". Match by prefix.
+		return podName == workloadName || (len(podName) > len(workloadName)+1 && strings.HasPrefix(podName, workloadName+"-"))
+	}
 }

--- a/pkg/recommend/docs.go
+++ b/pkg/recommend/docs.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 Serge Logvinov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package recommend provides functionality to analyze resource usage and generate recommendations for Kubernetes workloads.
+package recommend

--- a/pkg/recommend/recommendation.go
+++ b/pkg/recommend/recommendation.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package recommend provides functionality to analyze resource usage and generate recommendations for Kubernetes workloads.
 package recommend
 
 import (
@@ -49,11 +48,11 @@ func AnalyzeRecommendations(res []resources.ResourceInfo) []resources.ResourceRe
 		rec.CurrentMemLimit = r.MemLimit
 
 		if r.CPUUsage > 0 && r.CPURequest > 0 && r.CPUUsage > r.CPURequest {
-			recommendedCPU := roundUpCPU(int64(float64(r.CPUUsage) * 1.2))
+			recommendedCPU := roundUpCPULow(r.CPUUsage)
 			rec.RecommendedCPURequest = recommendedCPU
 
-			recommendedCPULimit := roundUpCPU(int64(float64(r.CPUUsage) * 2.0))
-			if recommendedCPULimit != rec.CurrentCPULimit {
+			recommendedCPULimit := roundUpCPUHigh(r.CPUUsage)
+			if recommendedCPULimit >= rec.CurrentCPULimit {
 				rec.RecommendedCPULimit = recommendedCPULimit
 			}
 
@@ -61,11 +60,11 @@ func AnalyzeRecommendations(res []resources.ResourceInfo) []resources.ResourceRe
 		}
 
 		if r.MemUsage > 0 && r.MemRequest > 0 && r.MemUsage > r.MemRequest {
-			recommendedMem := roundUpMemory(int64(float64(r.MemUsage) * 1.2))
+			recommendedMem := roundUpMemoryLow(r.MemUsage)
 			rec.RecommendedMemRequest = recommendedMem
 
-			recommendedMemLimit := roundUpMemory(int64(float64(r.MemUsage) * 2.0))
-			if recommendedMemLimit != rec.CurrentMemLimit {
+			recommendedMemLimit := roundUpMemoryHigh(r.MemUsage)
+			if recommendedMemLimit >= rec.CurrentMemLimit {
 				rec.RecommendedMemLimit = recommendedMemLimit
 			}
 
@@ -78,24 +77,4 @@ func AnalyzeRecommendations(res []resources.ResourceInfo) []resources.ResourceRe
 	}
 
 	return recommendations
-}
-
-func roundUpCPU(milliCores int64) int64 {
-	if milliCores <= 0 {
-		return int64(100)
-	}
-
-	increment := int64(500) // 500m
-
-	return ((milliCores + increment - 1) / increment) * increment
-}
-
-func roundUpMemory(bytes int64) int64 {
-	if bytes <= 0 {
-		return int64(64 * 1024 * 1024)
-	}
-
-	increment := int64(128 * 1024 * 1024) // 128Mi in bytes
-
-	return ((bytes + increment - 1) / increment) * increment
 }

--- a/pkg/recommend/round.go
+++ b/pkg/recommend/round.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 Serge Logvinov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recommend
+
+const (
+	// CPULowMultiplier defines the multiplier for CPU recommendation requests (20% increase).
+	CPULowMultiplier = 1.2
+	// CPUHighMultiplier defines the multiplier for CPU recommendation limits (100% increase).
+	CPUHighMultiplier = 2.0
+	// CPUMinimumRequest defines the minimum CPU request in milli-cores (50m).
+	CPUMinimumRequest = 50
+	// MemoryLowMultiplier defines the multiplier for memory recommendation requests (20% increase).
+	MemoryLowMultiplier = 1.2
+	// MemoryHighMultiplier defines the multiplier for memory recommendation limits (100% increase).
+	MemoryHighMultiplier = 2.0
+	// MemoryMinimumRequest defines the minimum memory request in bytes (64Mi).
+	MemoryMinimumRequest = 64 * 1024 * 1024 // 64Mi
+)
+
+func roundUpCPULow(milliCores int64) int64 {
+	if milliCores <= CPUMinimumRequest {
+		return int64(CPUMinimumRequest)
+	}
+
+	increment := int64(500) // 500m
+	if milliCores < 1000 {
+		increment = 100 // 100m for values less than 1 core
+	}
+
+	target := int64(float64(milliCores) * CPULowMultiplier)
+
+	return ((target + increment - 1) / increment) * increment
+}
+
+func roundUpCPUHigh(milliCores int64) int64 {
+	if milliCores <= CPUMinimumRequest {
+		return int64(CPUMinimumRequest)
+	}
+
+	increment := int64(500) // 500m
+	if milliCores < 1000 {
+		increment = 100 // 100m for values less than 1 core
+	}
+
+	target := int64(float64(milliCores) * CPUHighMultiplier)
+
+	return ((target + increment - 1) / increment) * increment
+}
+
+func roundUpMemoryLow(bytes int64) int64 {
+	if bytes <= MemoryMinimumRequest {
+		return MemoryMinimumRequest
+	}
+
+	increment := int64(128 * 1024 * 1024) // 128Mi in bytes
+	target := int64(float64(bytes) * MemoryLowMultiplier)
+
+	return ((target + increment - 1) / increment) * increment
+}
+
+func roundUpMemoryHigh(bytes int64) int64 {
+	if bytes <= MemoryMinimumRequest {
+		return MemoryMinimumRequest
+	}
+
+	increment := int64(128 * 1024 * 1024) // 128Mi in bytes
+	target := int64(float64(bytes) * MemoryHighMultiplier)
+
+	return ((target + increment - 1) / increment) * increment
+}

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -19,35 +19,40 @@ package resources
 
 // ResourceInfo represents the resource requests, limits, and usage for a container within a workload.
 type ResourceInfo struct {
-	Chart      string `json:"chart"`
-	Release    string `json:"release"`
-	Kind       string `json:"kind"`
-	Name       string `json:"name"`
-	Replicas   string `json:"replicas,omitempty"`
-	Container  string `json:"container"`
-	CPURequest int64  `json:"cpu_request,omitempty"`    // millicores
-	CPULimit   int64  `json:"cpu_limit,omitempty"`      // millicores
-	MemRequest int64  `json:"memory_request,omitempty"` // bytes
-	MemLimit   int64  `json:"memory_limit,omitempty"`   // bytes
-	CPUUsage   int64  `json:"cpu_usage,omitempty"`      // millicores
-	MemUsage   int64  `json:"memory_usage,omitempty"`   // bytes
+	Chart     string `json:"chart"`
+	Release   string `json:"release"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Replicas  string `json:"replicas,omitempty"`
+	Container string `json:"container"`
+	// Usage
+	CPUUsage int64 `json:"cpu_usage,omitempty"`    // millicores
+	MemUsage int64 `json:"memory_usage,omitempty"` // bytes
+	// Requests
+	CPURequest int64 `json:"cpu_request,omitempty"`    // millicores
+	MemRequest int64 `json:"memory_request,omitempty"` // bytes
+	// Limits
+	CPULimit int64 `json:"cpu_limit,omitempty"`    // millicores
+	MemLimit int64 `json:"memory_limit,omitempty"` // bytes
 }
 
 // ResourceRecommendation represents resource recommendation for a container within a workload.
 type ResourceRecommendation struct {
-	Chart                 string
-	Release               string
-	Kind                  string
-	Name                  string
-	Container             string
-	CPUUsage              int64 // millicores
-	MemUsage              int64 // bytes
+	Chart     string
+	Release   string
+	Kind      string
+	Name      string
+	Container string
+	CPUUsage  int64 // millicores
+	MemUsage  int64 // bytes
+	// Requests
 	CurrentCPURequest     int64 // millicores
 	RecommendedCPURequest int64 // millicores
 	CurrentMemRequest     int64 // bytes
 	RecommendedMemRequest int64 // bytes
-	CurrentCPULimit       int64 // millicores
-	RecommendedCPULimit   int64 // millicores
-	CurrentMemLimit       int64 // bytes
-	RecommendedMemLimit   int64 // bytes
+	// Limits
+	CurrentCPULimit     int64 // millicores
+	RecommendedCPULimit int64 // millicores
+	CurrentMemLimit     int64 // bytes
+	RecommendedMemLimit int64 // bytes
 }


### PR DESCRIPTION
Retrieve CPU and memory usage statistics from the Kubernetes Metrics API (metrics.k8s.io/v1).

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes Metrics API support for retrieving workload CPU and memory usage.
  * Improved resource recommendations with configurable rounding, minimum thresholds, and separate request/limit tuning.
  * Added clearer organization for resource usage, requests, and limits.

* **Bug Fixes**
  * Prevented resource limits from being reduced when recommendations do not warrant an increase.

* **Refactor**
  * Consolidated metrics retrieval across supported data sources for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->