### PR TITLE
refactor: flags and output

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 Serge Logvinov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	flagNamespace           = "namespace"
+	flagOutput              = "output"
+	flagValues              = "values"
+	flagPrometheusURL       = "prometheus-url"
+	envPrometheusURL        = "PROMETHEUS_URL"
+	flagMetricsWindow       = "metrics-window"
+	envMetricsWindow        = "METRICS_WINDOW"
+	flagAggregation         = "aggregation"
+	envAggregation          = "AGGREGATION"
+	flagShowStats           = "show-stats"
+	flagShowRecommendations = "show-recommendations"
+	flagNoHeaders           = "no-headers"
+)
+
+// Flags represents the command-line flags for the helm-resources command.
+type Flags struct {
+	Namespace           string
+	Output              string
+	Values              []string
+	PrometheusURL       string
+	MetricsWindow       string
+	Aggregation         string
+	ShowStats           bool
+	ShowRecommendations bool
+	NoHeaders           bool
+}
+
+// DefaultFlags returns the default flags for the command.
+func DefaultFlags() *Flags {
+	return &Flags{
+		ShowStats:           true,
+		ShowRecommendations: true,
+		NoHeaders:           false,
+	}
+}
+
+// AddFlags adds the command-line flags to the provided FlagSet.
+func (f *Flags) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVarP(&f.Namespace, flagNamespace, "n", "", "namespace of the release")
+	flags.StringVarP(&f.Output, flagOutput, "o", "table", "output format (table, json, yaml)")
+	flags.StringArrayVarP(&f.Values, flagValues, "f", []string{}, "Apply recommendations to values.yaml file (can be specified multiple times)")
+
+	// Prometheus and metrics aggregation flags
+	flags.StringVar(&f.PrometheusURL, flagPrometheusURL, withDefaultString(envPrometheusURL, ""), "Prometheus server URL for metrics (e.g., http://prometheus:9090)")
+	flags.StringVar(&f.MetricsWindow, flagMetricsWindow, withDefaultString(envMetricsWindow, "1h"), "Time window for metrics queries (e.g., 5m, 1h, 24h)")
+	flags.StringVar(&f.Aggregation, flagAggregation, withDefaultString(envAggregation, "avg"), "Aggregation function for metrics (avg, max)")
+
+	// Output formatting flags
+	flags.BoolVar(&f.ShowStats, flagShowStats, f.ShowStats, "Show resource statistics")
+	flags.BoolVar(&f.ShowRecommendations, flagShowRecommendations, f.ShowRecommendations, "Show resource recommendations")
+	flags.BoolVar(&f.NoHeaders, flagNoHeaders, f.NoHeaders, "Do not print table headers")
+}
+
+func withDefaultString(key string, def string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+
+	return val
+}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const none = "<none>"
+const none = "-"
 
 func outputJSON(resources []resources.ResourceInfo) error {
 	encoder := json.NewEncoder(os.Stdout)
@@ -47,9 +47,12 @@ func outputYAML(resources []resources.ResourceInfo) error {
 	return nil
 }
 
-func outputTable(resources []resources.ResourceInfo) error {
+func outputTable(f *Flags, resources []resources.ResourceInfo) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(w, "KIND\tNAME\tREPLICAS\tCONTAINER\tREQUESTS (CPU/MEM)\tLIMITS (CPU/MEM)\tUSAGE (CPU/MEM)\n")
+
+	if !f.NoHeaders {
+		fmt.Fprintf(w, "KIND\tNAME\tREPLICAS\tCONTAINER\tREQUESTS (CPU/MEM)\tLIMITS (CPU/MEM)\tUSAGE (CPU/MEM)\n")
+	}
 
 	for _, res := range resources {
 		requestsInfo := formatResourceValues(res.CPURequest, res.MemRequest)
@@ -69,25 +72,35 @@ func outputTable(resources []resources.ResourceInfo) error {
 	return w.Flush()
 }
 
-func outputTableRecommendations(recommendations []resources.ResourceRecommendation) error {
+func outputTableRecommendations(f *Flags, recommendations []resources.ResourceRecommendation) error {
 	if len(recommendations) > 0 {
-		fmt.Printf("\nRESOURCE RECOMMENDATIONS:\n\n")
-
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "KIND\tNAME\tCONTAINER\tREQUESTS (CPU/MEM)\tLIMITS (CPU/MEM)\tUSAGE (CPU/MEM)\n")
+
+		if !f.NoHeaders {
+			if f.ShowStats {
+				fmt.Printf("\nResource recommendations to adjust:\n\n")
+			}
+
+			fmt.Fprintf(w, "KIND\tNAME\tCONTAINER\tREQUESTS (CPU/MEM)\tREQUESTS DIFF (%%)\tLIMITS (CPU/MEM)\tLIMITS DIFF (%%)\tUSAGE (CPU/MEM)\n")
+		}
 
 		for _, rec := range recommendations {
 			requestsInfo := formatResourceValues(rec.RecommendedCPURequest, rec.RecommendedMemRequest)
+			requestsDiff := formatPercentageDiff(rec.CurrentCPURequest, rec.RecommendedCPURequest, rec.CurrentMemRequest, rec.RecommendedMemRequest)
 			limitsInfo := formatResourceValues(rec.RecommendedCPULimit, rec.RecommendedMemLimit)
+			limitsDiff := formatPercentageDiff(rec.CurrentCPULimit, rec.RecommendedCPULimit, rec.CurrentMemLimit, rec.RecommendedMemLimit)
 			usageInfo := formatResourceValues(rec.CPUUsage, rec.MemUsage)
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				rec.Kind,
 				rec.Name,
 				rec.Container,
 				requestsInfo,
+				requestsDiff,
 				limitsInfo,
-				usageInfo)
+				limitsDiff,
+				usageInfo,
+			)
 		}
 
 		return w.Flush()
@@ -134,4 +147,33 @@ func formatMemory(bytes int64) string {
 	}
 
 	return fmt.Sprintf("%d", bytes)
+}
+
+func formatPercentageDiff(currentCPU, recommendedCPU, currentMem, recommendedMem int64) string {
+	cpuDiff := calculatePercentageDiff(currentCPU, recommendedCPU)
+	memDiff := calculatePercentageDiff(currentMem, recommendedMem)
+
+	if cpuDiff == none && memDiff == none {
+		return none
+	}
+
+	return fmt.Sprintf("%s/%s", cpuDiff, memDiff)
+}
+
+func calculatePercentageDiff(current, recommended int64) string {
+	if current == 0 || recommended == 0 {
+		return none
+	}
+
+	diff := float64(recommended-current) / float64(current) * 100
+
+	if diff > 0 {
+		return fmt.Sprintf("+%.0f%%", diff)
+	}
+
+	if diff > -0.5 {
+		return "0%"
+	}
+
+	return fmt.Sprintf("%.0f%%", diff)
 }

--- a/cmd/resources.go
+++ b/cmd/resources.go
@@ -43,7 +43,16 @@ This command analyzes a deployed helm release and displays the CPU and memory
 requests and limits for all deployments, statefulsets, daemonsets, and cronjobs managed by the release.
 `
 
+// CommandOptions represents the options of the command.
+type CommandOptions struct {
+	Flags *Flags
+}
+
 func newResourcesCommand() *cobra.Command {
+	opts := CommandOptions{
+		Flags: DefaultFlags(),
+	}
+
 	cmd := &cobra.Command{
 		Use:   "resources [RELEASE] [flags]",
 		Short: "Show workload resources",
@@ -55,35 +64,21 @@ func newResourcesCommand() *cobra.Command {
 			"  helm resources my-release --values values.yaml",
 		}, "\n"),
 		Args: cobra.ExactArgs(1),
-		RunE: runResources,
+		RunE: opts.RunResources,
 	}
 
-	cmd.Flags().StringP("namespace", "n", "", "namespace of the release")
-	cmd.Flags().StringP("output", "o", "table", "output format (table, json, yaml)")
-	cmd.Flags().StringArrayP("values", "f", []string{}, "Apply recommendations to values.yaml file (can be specified multiple times)")
-	cmd.Flags().String("prometheus-url", "", "Prometheus server URL for metrics (e.g., http://prometheus:9090)")
-	cmd.Flags().String("metrics-window", "5m", "Time window for metrics queries (e.g., 5m, 1h, 24h)")
-	cmd.Flags().String("aggregation", "avg", "Aggregation function for metrics (avg, max)")
+	opts.Flags.AddFlags(cmd.Flags())
 
 	return cmd
 }
 
-func runResources(cmd *cobra.Command, args []string) error {
+// RunResources executes the helm-resources command.
+func (o *CommandOptions) RunResources(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	flags := cmd.Flags()
-
-	releaseName := args[0]
-	namespace, _ := flags.GetString("namespace")       //nolint: errcheck
-	outputFormat, _ := flags.GetString("output")       //nolint: errcheck
-	applyToValues, _ := flags.GetStringArray("values") //nolint: errcheck
-
-	prometheusURL, _ := flags.GetString("prometheus-url") //nolint: errcheck
-	metricsWindow, _ := flags.GetString("metrics-window") //nolint: errcheck
-	aggregation, _ := flags.GetString("aggregation")      //nolint: errcheck
 
 	settings := cli.New()
-	if namespace != "" {
-		settings.SetNamespace(namespace)
+	if o.Flags.Namespace != "" {
+		settings.SetNamespace(o.Flags.Namespace)
 	}
 
 	actionConfig := new(action.Configuration)
@@ -93,7 +88,7 @@ func runResources(cmd *cobra.Command, args []string) error {
 
 	getAction := action.NewGet(actionConfig)
 
-	release, err := getAction.Run(releaseName)
+	release, err := getAction.Run(args[0])
 	if err != nil {
 		return err
 	}
@@ -108,7 +103,7 @@ func runResources(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	metricsClient, err := metrics.New(prometheusURL, metricsWindow, aggregation, config)
+	metricsClient, err := metrics.New(o.Flags.PrometheusURL, o.Flags.MetricsWindow, o.Flags.Aggregation, config)
 	if err != nil {
 		return fmt.Errorf("failed to create metrics client: %w", err)
 	}
@@ -118,18 +113,16 @@ func runResources(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to extract resources: %w", err)
 	}
 
-	recommendations := recommend.AnalyzeRecommendations(resInfos)
-	if len(applyToValues) > 0 && len(recommendations) > 0 {
-		if err := applyRecommendationsToValuesFiles(recommendations, applyToValues); err != nil {
-			return err
-		}
-
-		return nil
-	}
-
 	var errs error
 
-	switch outputFormat {
+	recommendations := recommend.AnalyzeRecommendations(resInfos)
+	if len(o.Flags.Values) > 0 && len(recommendations) > 0 {
+		if err := applyRecommendationsToValuesFiles(recommendations, o.Flags.Values); err != nil {
+			errs = multierr.Append(errs, err)
+		}
+	}
+
+	switch o.Flags.Output {
 	case "json":
 		if err = outputJSON(resInfos); err != nil {
 			errs = multierr.Append(errs, err)
@@ -139,12 +132,16 @@ func runResources(cmd *cobra.Command, args []string) error {
 			errs = multierr.Append(errs, err)
 		}
 	default:
-		if err = outputTable(resInfos); err != nil {
-			errs = multierr.Append(errs, err)
+		if o.Flags.ShowStats && len(resInfos) > 0 {
+			if err = outputTable(o.Flags, resInfos); err != nil {
+				errs = multierr.Append(errs, err)
+			}
 		}
 
-		if err = outputTableRecommendations(recommendations); err != nil {
-			errs = multierr.Append(errs, err)
+		if o.Flags.ShowRecommendations && len(recommendations) > 0 {
+			if err = outputTableRecommendations(o.Flags, recommendations); err != nil {
+				errs = multierr.Append(errs, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Move flag definitions into a dedicated file.
Add support for overriding selected command-line flags through environment variables.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line options for namespace, output format, values files, metrics settings, statistics, recommendations, and table headers.
  * Metrics-related defaults can be configured through environment variables.
  * Recommendation tables now show percentage differences for resource requests and limits.

* **Enhancements**
  * Statistics and recommendations can be displayed independently.
  * Table headers can be hidden for streamlined output.
  * Missing values are displayed as `-`.
  * Multiple values-file update errors are reported together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->