### PR TITLE
fix: handle empty inline maps when adding resource structure

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -366,15 +366,34 @@ func addMissingResourceStructure(
 			strings.Repeat(" ", baseIndent+2) + resource + ": " + newValue,
 		}
 		insertPos = findInsertPosition(lines, resourcesLine, resourcesIndent)
+
+		// An empty inline resources block (e.g. "resources: {}") must drop
+		// the "{}" marker so the new fields can be inserted underneath it.
+		if resourcesLine >= 0 {
+			lines[resourcesLine] = stripInlineEmptyMap(lines[resourcesLine])
+		}
 	default:
 		baseIndent := resourceTypeIndent + 2
 		insertLines = []string{
 			strings.Repeat(" ", baseIndent) + resource + ": " + newValue,
 		}
 		insertPos = findInsertPosition(lines, resourceTypeLine, resourceTypeIndent)
+
+		// An empty inline type block (e.g. "limits: {}").
+		if resourceTypeLine >= 0 {
+			lines[resourceTypeLine] = stripInlineEmptyMap(lines[resourceTypeLine])
+		}
 	}
 
 	return append(lines[:insertPos], append(insertLines, lines[insertPos:]...)...)
+}
+
+func stripInlineEmptyMap(line string) string {
+	if !strings.HasSuffix(strings.TrimSpace(line), "{}") {
+		return line
+	}
+
+	return strings.TrimRight(strings.TrimSuffix(line, "{}"), " \t")
 }
 
 func findInsertPosition(lines []string, startLine, baseIndent int) int {

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -44,6 +44,25 @@ componentName:
       memory: 768Mi
 `
 
+	complexYAML = `
+someOtherField: someValue
+resources: {}
+
+configRaw: |-
+  some config
+  with multiple lines
+
+componentName:
+  otherField: someValue
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 768Mi
+`
+
 	simpleServiceYAML = `
 someOtherField: someValue
 services:
@@ -154,6 +173,42 @@ componentName:
     requests:
       cpu: 100m
       memory: 256Mi
+`,
+		},
+		{
+			name: "common deploy with complex yaml",
+			yaml: complexYAML,
+			resources: resources.ResourceRecommendation{
+				Release:               "common",
+				Name:                  "common",
+				RecommendedCPURequest: 100,
+				RecommendedMemRequest: 256 * 1024 * 1024,
+				RecommendedCPULimit:   200,
+				RecommendedMemLimit:   512 * 1024 * 1024,
+			},
+			expect: `
+someOtherField: someValue
+resources:
+  limits:
+    cpu: 200m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+configRaw: |-
+  some config
+  with multiple lines
+
+componentName:
+  otherField: someValue
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 768Mi
 `,
 		},
 		{


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

Patching YAML with empty inline maps (e.g. `resources: {}`).

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
