### PR TITLE
fix: match keys with scalar values

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -86,7 +86,7 @@ func ApplyPatchesToYaml(yamlText string, res resources.ResourceRecommendation) (
 
 		newText, err := applyResourcePatchesToPath(yamlText, path, res)
 		if err != nil {
-			return "", fmt.Errorf("failed to apply resource patches to path %w", err)
+			return "", fmt.Errorf("failed to apply resource patches to path: %w", err)
 		}
 
 		yamlText = newText
@@ -212,7 +212,7 @@ func findTargetLocation(lines []string, path WorkloadPath) (int, int, error) {
 			return i - 1, indent, nil
 		}
 
-		return -1, 0, fmt.Errorf("target location not found")
+		return -1, 0, ErrNotFound
 	}
 
 	for i, line := range lines {
@@ -228,7 +228,7 @@ func findTargetLocation(lines []string, path WorkloadPath) (int, int, error) {
 		}
 
 		if !workloadFound {
-			if strings.HasPrefix(trimmed, path.Workload+":") {
+			if strings.HasPrefix(trimmed, path.Workload+":") && !lineHasValue(trimmed) {
 				workloadFound = true
 
 				if path.Container == "" {
@@ -264,7 +264,7 @@ func findTargetLocation(lines []string, path WorkloadPath) (int, int, error) {
 		}
 	}
 
-	return -1, 0, fmt.Errorf("target location not found: %s/%s/%s", path.Section, path.Workload, path.Container)
+	return -1, 0, fmt.Errorf("target location %s/%s/%s: %w", path.Section, path.Workload, path.Container, ErrNotFound)
 }
 
 func findResourcesSection(lines []string, startLine, baseIndent int) (int, int) {
@@ -394,6 +394,27 @@ func stripInlineEmptyMap(line string) string {
 	}
 
 	return strings.TrimRight(strings.TrimSuffix(line, "{}"), " \t")
+}
+
+// lineHasValue reports whether a YAML line carries a scalar value, for example
+// "metrics: |-" or "cpu: 100m". Structural markers such as anchors, aliases,
+// and empty inline collections ("{}", "[]") are not considered values.
+func lineHasValue(line string) bool {
+	keyVal := strings.SplitN(strings.TrimSpace(line), ":", 2)
+	if len(keyVal) < 2 {
+		return false
+	}
+
+	value := strings.TrimSpace(strings.TrimSuffix(keyVal[1], "#"))
+
+	switch {
+	case value == "", value == "{}", value == "[]":
+		return false
+	case strings.HasPrefix(value, "&"), strings.HasPrefix(value, "*"):
+		return false
+	}
+
+	return true
 }
 
 func findInsertPosition(lines []string, startLine, baseIndent int) int {

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -54,6 +54,11 @@ configRaw: |-
 
 componentName:
   otherField: someValue
+  metrics: |-
+    resources:
+      requests:
+        cpu: 100m
+
   resources:
     limits:
       cpu: 500m
@@ -202,6 +207,11 @@ configRaw: |-
 
 componentName:
   otherField: someValue
+  metrics: |-
+    resources:
+      requests:
+        cpu: 100m
+
   resources:
     limits:
       cpu: 500m
@@ -210,6 +220,20 @@ componentName:
       cpu: 100m
       memory: 768Mi
 `,
+		},
+		{
+			name: "common deploy with complex yaml not found",
+			yaml: complexYAML,
+			resources: resources.ResourceRecommendation{
+				Release:               "common",
+				Name:                  "common",
+				Container:             "metrics",
+				RecommendedCPURequest: 200,
+				RecommendedMemRequest: 256 * 1024 * 1024,
+				RecommendedCPULimit:   200,
+				RecommendedMemLimit:   512 * 1024 * 1024,
+			},
+			expectErr: patch.ErrNotFound,
 		},
 		{
 			name: "service not found",


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

Add a check to ensure YAML keys are followed by scalar values and are not left without a value.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when patch targets or applications cannot be found.
  * Refined workload matching to correctly handle scalar YAML values while preserving support for nested mappings and empty collections.
  * Improved handling of nested resource configurations and nonexistent YAML containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->