### PR TITLE
fix: handle comments after inline empty maps

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -389,11 +389,17 @@ func addMissingResourceStructure(
 }
 
 func stripInlineEmptyMap(line string) string {
-	if !strings.HasSuffix(strings.TrimSpace(line), "{}") {
+	keyVal := strings.SplitN(line, ":", 2)
+	if len(keyVal) < 2 {
 		return line
 	}
 
-	return strings.TrimRight(strings.TrimSuffix(line, "{}"), " \t")
+	value := strings.TrimLeft(keyVal[1], " ")
+	if !strings.HasPrefix(value, "{}") {
+		return line
+	}
+
+	return keyVal[0] + ":"
 }
 
 // lineHasValue reports whether a YAML line carries a scalar value, for example

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -28,7 +28,7 @@ import (
 const (
 	commonYAML = `
 someOtherField: someValue
-resources:
+resources: # Comment lines
   requests:
     cpu: 50m
     memory: 128Mi
@@ -46,7 +46,7 @@ componentName:
 
 	complexYAML = `
 someOtherField: someValue
-resources: {}
+resources: {}  # Undefined values comment example
 
 configRaw: |-
   some config
@@ -132,7 +132,7 @@ func TestApplyPatchesToYaml(t *testing.T) {
 			},
 			expect: `
 someOtherField: someValue
-resources:
+resources: # Comment lines
   requests:
     cpu: 100m
     memory: 256Mi
@@ -164,7 +164,7 @@ componentName:
 			},
 			expect: `
 someOtherField: someValue
-resources:
+resources: # Comment lines
   requests:
     cpu: 50m
     memory: 128Mi


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Check the value after the colon instead of the trimmed line suffix so trailing comments no longer prevent an empty map from being stripped.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty inline map values so unrelated lines remain unchanged.
  * Preserved inline comments on top-level resource fields when applying patches.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->